### PR TITLE
feat(NumericUpDown): add SyncTextWithValueWhileEditing to refresh text on external value change

### DIFF
--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1121,12 +1121,14 @@ namespace MahApps.Metro.Controls
             }
             else if (this.SyncTextWithValueWhileEditing && this.valueTextBox != null)
             {
-                var expectedText = newValue.HasValue ? FormattedValueString(newValue.Value, this.StringFormat, this.SpecificCultureInfo)
-                                                     : null;
-                if (!string.Equals(this.valueTextBox.Text, expectedText, StringComparison.Ordinal))
+                var textRepresentsValue = newValue.HasValue
+                                          && this.ValidateText(this.valueTextBox.Text, out var textValue)
+                                          && FormattedValue(textValue, this.StringFormat, this.SpecificCultureInfo) == newValue.Value;
+
+                if (!textRepresentsValue)
                 {
                     this.InternalSetText(newValue);
-                    
+
                     if (this.valueTextBox.IsKeyboardFocused)
                     {
                         this.valueTextBox.SelectAll();

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1126,6 +1126,11 @@ namespace MahApps.Metro.Controls
                 if (!string.Equals(this.valueTextBox.Text, expectedText, StringComparison.Ordinal))
                 {
                     this.InternalSetText(newValue);
+                    
+                    if (this.valueTextBox.IsKeyboardFocused)
+                    {
+                        this.valueTextBox.SelectAll();
+                    }
                 }
             }
 

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -359,6 +359,28 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(InterceptManualEnterProperty, BooleanBoxes.Box(value));
         }
 
+        /// <summary>Identifies the <see cref="SyncTextWithValueWhileEditing"/> dependency property.</summary>
+        public static readonly DependencyProperty SyncTextWithValueWhileEditingProperty
+            = DependencyProperty.Register(nameof(SyncTextWithValueWhileEditing),
+                                          typeof(bool),
+                                          typeof(NumericUpDown),
+                                          new PropertyMetadata(BooleanBoxes.FalseBox));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the displayed text is kept in sync with the
+        /// <see cref="Value"/> while the control is being edited (has keyboard focus), when the value
+        /// is changed from an external source such as a binding. When set to <see langword="false"/>
+        /// (the default), the current behavior is kept: the text is only refreshed from the value once
+        /// the control loses focus.
+        /// </summary>
+        [Category("Behavior")]
+        [DefaultValue(false)]
+        public bool SyncTextWithValueWhileEditing
+        {
+            get => (bool)this.GetValue(SyncTextWithValueWhileEditingProperty);
+            set => this.SetValue(SyncTextWithValueWhileEditingProperty, BooleanBoxes.Box(value));
+        }
+
         /// <summary>Identifies the <see cref="Value"/> dependency property.</summary>
         public static readonly DependencyProperty ValueProperty
             = DependencyProperty.Register(nameof(Value),
@@ -1093,6 +1115,15 @@ namespace MahApps.Metro.Controls
                 }
 
                 if (this.valueTextBox != null)
+                {
+                    this.InternalSetText(newValue);
+                }
+            }
+            else if (this.SyncTextWithValueWhileEditing && this.valueTextBox != null)
+            {
+                var expectedText = newValue.HasValue ? FormattedValueString(newValue.Value, this.StringFormat, this.SpecificCultureInfo)
+                                                     : null;
+                if (!string.Equals(this.valueTextBox.Text, expectedText, StringComparison.Ordinal))
                 {
                     this.InternalSetText(newValue);
                 }


### PR DESCRIPTION
When enabled, the displayed text is kept in sync with Value while the control has focus and the value changes from an external source (e.g. a binding reverting it). Defaults to false, preserving the current behavior of only refreshing the text on lost focus.